### PR TITLE
Run in-nixpkgs check inside commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Nix artifacts
+result

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,2 @@
-language: python
-python:
-  - "3.6"
-  - "3.7-dev"
-install:
-  - pip install -e .[dev]
-script:
-  - python3 -m unittest discover .
-  - mypy nix_review
-  - flake8
-  # broken on 3.7 atm (https://github.com/ambv/black/issues/425)
-  - |
-    [[ $TRAVIS_PYTHON_VERSION == 3.7-dev ]] || black --check .
+language: nix
+script: nix-build --quiet release.nix -A build.x86_64-linux 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: nix
-script: nix-build --quiet release.nix -A build.x86_64-linux 
+script: nix-build --quiet

--- a/nix_review/buildenv.py
+++ b/nix_review/buildenv.py
@@ -1,11 +1,35 @@
 import os
+import sys
 from tempfile import NamedTemporaryFile
-from typing import Any
+from typing import Any, Optional
+
+from .utils import warn
+
+
+def find_nixpkgs_root() -> Optional[str]:
+    prefix = ["."]
+    release_nix = ["nixos", "release.nix"]
+    while True:
+        root_path = os.path.join(*prefix)
+        release_nix_path = os.path.join(root_path, *release_nix)
+        if os.path.exists(release_nix_path):
+            return root_path
+        if os.path.abspath(root_path) == "/":
+            return None
+        prefix.append("..")
 
 
 class Buildenv:
     def __enter__(self) -> None:
         self.environ = os.environ.copy()
+        self.old_cwd = os.getcwd()
+
+        root = find_nixpkgs_root()
+        if root is None:
+            warn("Has to be execute from nixpkgs repository")
+            sys.exit(1)
+        else:
+            os.chdir(root)
 
         os.environ["GIT_AUTHOR_NAME"] = "nix-review"
         os.environ["GIT_AUTHOR_EMAIL"] = "nix-review@example.com"
@@ -18,6 +42,12 @@ class Buildenv:
         os.environ["NIXPKGS_CONFIG"] = self.nixpkgs_config.name
 
     def __exit__(self, _type: Any, _value: Any, _traceback: Any) -> None:
+        if self.old_cwd is not None:
+            try:
+                os.chdir(self.old_cwd)
+            except OSError:  # could be deleted
+                pass
+
         if self.environ is not None:
             os.environ.clear()
             os.environ.update(self.environ)

--- a/nix_review/cli.py
+++ b/nix_review/cli.py
@@ -27,7 +27,6 @@ def parse_pr_numbers(number_args: List[str]) -> List[int]:
 
 
 def pr_command(args: argparse.Namespace) -> None:
-    chdir_nixpkgs_root()
 
     prs = parse_pr_numbers(args.number)
     use_ofborg_eval = args.eval == "ofborg"
@@ -66,7 +65,6 @@ def pr_command(args: argparse.Namespace) -> None:
 
 
 def rev_command(args: argparse.Namespace) -> None:
-    chdir_nixpkgs_root()
     with Worktree(f"rev-{args.commit}") as worktree:
         r = Review(
             worktree_dir=worktree.worktree_dir,
@@ -164,32 +162,6 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
         rev_parser.add_argument(*flag.args, **flag.kwargs)
 
     return parser.parse_args(args)
-
-
-def die(message: str) -> None:
-    print(message, file=sys.stderr)
-    sys.exit(1)
-
-
-def find_nixpkgs_root() -> Optional[str]:
-    prefix = ["."]
-    release_nix = ["nixos", "release.nix"]
-    while True:
-        root_path = os.path.join(*prefix)
-        release_nix_path = os.path.join(root_path, *release_nix)
-        if os.path.exists(release_nix_path):
-            return root_path
-        if os.path.abspath(root_path) == "/":
-            return None
-        prefix.append("..")
-
-
-def chdir_nixpkgs_root() -> None:
-    root = find_nixpkgs_root()
-    if root is None:
-        die("Has to be executed from nixpkgs repository")
-    else:
-        os.chdir(root)
 
 
 def main(command: str, raw_args: List[str]) -> None:

--- a/nix_review/cli.py
+++ b/nix_review/cli.py
@@ -27,6 +27,8 @@ def parse_pr_numbers(number_args: List[str]) -> List[int]:
 
 
 def pr_command(args: argparse.Namespace) -> None:
+    chdir_nixpkgs_root()
+
     prs = parse_pr_numbers(args.number)
     use_ofborg_eval = args.eval == "ofborg"
     checkout_option = (
@@ -64,6 +66,7 @@ def pr_command(args: argparse.Namespace) -> None:
 
 
 def rev_command(args: argparse.Namespace) -> None:
+    chdir_nixpkgs_root()
     with Worktree(f"rev-{args.commit}") as worktree:
         r = Review(
             worktree_dir=worktree.worktree_dir,
@@ -181,14 +184,16 @@ def find_nixpkgs_root() -> Optional[str]:
         prefix.append("..")
 
 
-def main(command: str, raw_args: List[str]) -> None:
-    args = parse_args(command, raw_args)
-
+def chdir_nixpkgs_root() -> None:
     root = find_nixpkgs_root()
     if root is None:
-        die("Has to be execute from nixpkgs repository")
+        die("Has to be executed from nixpkgs repository")
     else:
         os.chdir(root)
+
+
+def main(command: str, raw_args: List[str]) -> None:
+    args = parse_args(command, raw_args)
 
     with Buildenv():
         args.func(args)

--- a/nix_review/cli.py
+++ b/nix_review/cli.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import sys
 from contextlib import ExitStack
-from typing import Any, List, Optional
+from typing import Any, List
 
 from .review import CheckoutOption, Review, nix_shell
 from .worktree import Worktree


### PR DESCRIPTION
Before this check should be performed, the argument parsing should be
fully initialized. This ensures that `nix-review --help` always works,
even if you aren't in `~/nixpkgs`.