### PR TITLE
Implement support for `nix-review wip` to review uncommited changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,17 @@ $ nix-review rev HEAD
 
 Instead of `HEAD` also a commit or branch can be given.
 
+To review uncommited changes, use the following command:
+
+```console
+$ nix-review wip
+```
+
+Staged changes can be reviewed like this:
+
+```console
+$ nix-review wip --staged
+```
 
 ## Remote builder:
 

--- a/nix_review/cli/__init__.py
+++ b/nix_review/cli/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, List, Pattern
 from ..buildenv import Buildenv
 from .pr import pr_command
 from .rev import rev_command
+from .wip import wip_command
 
 
 def regex_type(s: str) -> Pattern[str]:
@@ -65,6 +66,27 @@ def rev_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser
     return rev_parser
 
 
+def wip_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    wip_parser = subparsers.add_parser(
+        "wip", help="review the uncommited changes in the working tree"
+    )
+
+    wip_parser.add_argument(
+        "-b", "--branch", default="master", help="branch to compare against with"
+    )
+    wip_parser.add_argument(
+        "-s",
+        "--staged",
+        action="store_true",
+        default=False,
+        help="Whether to build staged changes",
+    )
+
+    wip_parser.set_defaults(func=wip_command)
+
+    return wip_parser
+
+
 class CommonFlag:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.args = args
@@ -84,6 +106,7 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
     subparsers.required = True  # type: ignore
     pr_parser = pr_flags(subparsers)
     rev_parser = rev_flags(subparsers)
+    wip_parser = wip_flags(subparsers)
 
     common_flags = [
         CommonFlag(
@@ -108,6 +131,7 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
     for flag in common_flags:
         pr_parser.add_argument(*flag.args, **flag.kwargs)
         rev_parser.add_argument(*flag.args, **flag.kwargs)
+        wip_parser.add_argument(*flag.args, **flag.kwargs)
 
     return parser.parse_args(args)
 

--- a/nix_review/cli/rev.py
+++ b/nix_review/cli/rev.py
@@ -1,25 +1,9 @@
 import argparse
-import subprocess
 
-from ..builddir import Builddir
-from ..review import Review
+from ..utils import verify_commit_hash
+from ..review import review_local_revision
 
 
 def rev_command(args: argparse.Namespace) -> None:
-    commit = (
-        subprocess.run(
-            ["git", "rev-parse", "--verify", args.commit],
-            check=True,
-            stdout=subprocess.PIPE,
-        )
-        .stdout.decode("utf-8")
-        .strip()
-    )
-    with Builddir(f"rev-{commit}") as builddir:
-        review = Review(
-            builddir=builddir,
-            build_args=args.build_args,
-            only_packages=set(args.package),
-            package_regexes=args.package_regex,
-        )
-        review.review_commit(args.branch, commit)
+    commit = verify_commit_hash(args.commit)
+    review_local_revision(f"rev-{commit}", args, commit)

--- a/nix_review/cli/wip.py
+++ b/nix_review/cli/wip.py
@@ -1,0 +1,10 @@
+import argparse
+
+from ..utils import verify_commit_hash
+from ..review import review_local_revision
+
+
+def wip_command(args: argparse.Namespace) -> None:
+    review_local_revision(
+        "rev-%s-dirty" % verify_commit_hash("HEAD"), args, None, args.staged
+    )

--- a/nix_review/review.py
+++ b/nix_review/review.py
@@ -152,6 +152,7 @@ def list_packages(path: str, check_meta: bool = False) -> PackageSet:
     cmd = ["nix-env", "-f", path, "-qaP", "--xml", "--out-path", "--show-trace"]
     if check_meta:
         cmd.append("--meta")
+    info("$ " + " ".join(cmd))
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     packages = set()
     with proc as nix_env:

--- a/nix_review/review.py
+++ b/nix_review/review.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import subprocess
 import sys
@@ -9,7 +10,7 @@ from .builddir import Builddir
 from .github import GithubClient
 from .nix import Attr, nix_build, nix_eval, nix_shell
 from .report import Report
-from .utils import sh, warn
+from .utils import sh, warn, info
 
 
 class CheckoutOption(Enum):
@@ -54,14 +55,36 @@ class Review:
     def git_merge(self, commit: str) -> None:
         sh(["git", "merge", "--no-commit", commit], cwd=self.worktree_dir())
 
-    def build_commit(self, base_commit: str, reviewed_commit: str) -> List[Attr]:
+    def apply_unstaged(self, staged: bool = False) -> None:
+        args = ["git", "--no-pager", "diff"]
+        args.extend(["--staged"] if staged else [])
+        diff_proc = subprocess.Popen(args, stdout=subprocess.PIPE)
+        diff = diff_proc.stdout.read()
+
+        if not diff:
+            info("No diff detected, stopping review...")
+            sys.exit(0)
+
+        info("Applying `nixpkgs` diff...")
+        result = subprocess.run(["git", "apply"], cwd=self.worktree_dir(), input=diff)
+
+        if result.returncode != 0:
+            warn("Failed to apply diff in %s" % self.worktree_dir())
+            sys.exit(1)
+
+    def build_commit(
+        self, base_commit: str, reviewed_commit: Optional[str], staged: bool = False
+    ) -> List[Attr]:
         """
         Review a local git commit
         """
         self.git_worktree(base_commit)
         base_packages = list_packages(str(self.worktree_dir()))
 
-        self.git_merge(reviewed_commit)
+        if reviewed_commit is None:
+            self.apply_unstaged(staged)
+        else:
+            self.git_merge(reviewed_commit)
 
         merged_packages = list_packages(str(self.worktree_dir()), check_meta=True)
 
@@ -115,9 +138,11 @@ class Review:
         report.write(self.builddir.path, pr)
         nix_shell(report.built_packages(), self.builddir.path)
 
-    def review_commit(self, branch: str, reviewed_commit: str) -> None:
+    def review_commit(
+        self, branch: str, reviewed_commit: Optional[str], staged: bool = False
+    ) -> None:
         branch_rev = fetch_refs(branch)[0]
-        self.start_review(self.build_commit(branch_rev, reviewed_commit))
+        self.start_review(self.build_commit(branch_rev, reviewed_commit, staged))
 
 
 PackageSet = Set[Tuple[str, str]]
@@ -222,3 +247,19 @@ def fetch_refs(*refs: str) -> List[str]:
 def differences(old: PackageSet, new: PackageSet) -> Set[str]:
     raw = new - old
     return {l[0] for l in raw}
+
+
+def review_local_revision(
+    builddir_path: str,
+    args: argparse.Namespace,
+    commit: Optional[str],
+    staged: bool = False,
+) -> None:
+    with Builddir(builddir_path) as builddir:
+        review = Review(
+            builddir=builddir,
+            build_args=args.build_args,
+            only_packages=set(args.package),
+            package_regexes=args.package_regex,
+        )
+        review.review_commit(args.branch, commit, staged)

--- a/nix_review/tests/test_wip.py
+++ b/nix_review/tests/test_wip.py
@@ -1,0 +1,71 @@
+import unittest
+
+from typing import Any, List, Tuple
+from unittest.mock import MagicMock, patch
+
+from io import StringIO
+
+from nix_review.cli import main
+
+from .cli_mocks import (
+    CliTestCase,
+    build_cmds,
+    Mock,
+    IgnoreArgument,
+    MockCompletedProcess,
+    read_asset,
+)
+
+
+def wip_command_cmds() -> List[Tuple[Any, Any]]:
+    return [
+        (
+            ["git", "rev-parse", "--verify", "HEAD"],
+            MockCompletedProcess(stdout=b"hash1\n"),
+        ),
+        (
+            [
+                "git",
+                "fetch",
+                "--force",
+                "https://github.com/NixOS/nixpkgs",
+                "master:refs/nix-review/0",
+            ],
+            MockCompletedProcess(),
+        ),
+        (
+            ["git", "rev-parse", "--verify", "refs/nix-review/0"],
+            MockCompletedProcess(stdout=b"hash1\n"),
+        ),
+        (["git", "worktree", "add", IgnoreArgument, "hash1"], MockCompletedProcess()),
+        (IgnoreArgument, MockCompletedProcess(stdout=StringIO("<items></items>"))),
+        (["git", "apply"], MockCompletedProcess()),
+        (
+            IgnoreArgument,
+            MockCompletedProcess(stdout=StringIO(read_asset("package_list_after.txt"))),
+        ),
+    ]
+
+
+class WipCommand(CliTestCase):
+    @patch("subprocess.run")
+    @patch("subprocess.Popen")
+    def test_wip_command(self, mock_popen: MagicMock, mock_run: MagicMock) -> None:
+        effects = Mock(self, wip_command_cmds() + build_cmds)
+        mock_run.side_effect = effects
+
+        popen_instance = mock_popen.return_value
+        popen_instance.__enter__.side_effect = effects
+
+        main(
+            "nix-review",
+            [
+                "wip",
+                "--build-args",
+                '--builders "ssh://joerg@10.243.29.170 aarch64-linux"',
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(failfast=True)

--- a/nix_review/utils.py
+++ b/nix_review/utils.py
@@ -27,3 +27,13 @@ def sh(
 ) -> subprocess.CompletedProcess:
     info("$ " + " ".join(command))
     return subprocess.run(command, cwd=cwd, check=True)
+
+
+def verify_commit_hash(commit: str) -> str:
+    return (
+        subprocess.run(
+            ["git", "rev-parse", "--verify", commit], check=True, stdout=subprocess.PIPE
+        )
+        .stdout.decode("utf-8")
+        .strip()
+    )


### PR DESCRIPTION
This is the only feature that `nox-review` supports and I'm actually
missing here.

Unstaged (or staged changes with `-s`) will be applied onto the git
workspace in `~/.cache/nix-review/rev-{base hash}-dirty` using `git
apply` and tested after that.