### PR TITLE
Fix minor grammar issue in the log

### DIFF
--- a/nix_review/report.py
+++ b/nix_review/report.py
@@ -115,8 +115,8 @@ class Report:
             )
             write_number(f, self.blacklisted, "were blacklisted")
             write_number(f, self.failed, "failed to build")
-            write_number(f, self.tests, "were build", what="test")
-            write_number(f, self.built, "were build")
+            write_number(f, self.tests, "were built", what="test")
+            write_number(f, self.built, "were built")
 
     def print_console(self, pr: Optional[int]) -> None:
         if pr is not None:
@@ -128,5 +128,5 @@ class Report:
         )
         print_number(self.blacklisted, "were blacklisted")
         print_number(self.failed, "failed to build")
-        print_number(self.tests, "were build", what="tests", log=print)
-        print_number(self.built, "were build", log=print)
+        print_number(self.tests, "were built", what="tests", log=print)
+        print_number(self.built, "were built", log=print)


### PR DESCRIPTION
`n packages were built` is a simple past passive[1] which consists of a
past form of `to be` and a past participle (which is `built` in this
case).

[1] https://www.grammarbank.com/simple-past-passive.html