### PR TITLE
always start nix-shell

### DIFF
--- a/nix_review/nix.py
+++ b/nix_review/nix.py
@@ -48,12 +48,9 @@ class Attr:
 
 
 def nix_shell(attrs: List[str], cache_directory: Path) -> None:
-    if len(attrs) == 0:
-        info("No packages were successfully build, skip nix-shell")
-    else:
-        shell = cache_directory.joinpath("shell.nix")
-        write_shell_expression(shell, attrs)
-        sh(["nix-shell", str(shell)], cwd=cache_directory)
+    shell = cache_directory.joinpath("shell.nix")
+    write_shell_expression(shell, attrs)
+    sh(["nix-shell", str(shell)], cwd=cache_directory)
 
 
 def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:


### PR DESCRIPTION
fixes #45

Also if we don't build any packages it is still useful to spawn a nix-shell:

- the pr might only change services a user might want to test
- the ofborg evaluation might not contain proprietary packages