### PR TITLE
Add `--remote` option to `nix-review rev` for personal forks

### DIFF
--- a/nix_review/cli/__init__.py
+++ b/nix_review/cli/__init__.py
@@ -62,6 +62,12 @@ def rev_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser
     rev_parser.add_argument(
         "commit", help="commit/tag/ref/branch in your local git repository"
     )
+    rev_parser.add_argument(
+        "-r",
+        "--remote",
+        default="https://github.com/NixOS/nixpkgs",
+        help="Name of the nixpkgs repo to review",
+    )
     rev_parser.set_defaults(func=rev_command)
     return rev_parser
 
@@ -80,6 +86,12 @@ def wip_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser
         action="store_true",
         default=False,
         help="Whether to build staged changes",
+    )
+    wip_parser.add_argument(
+        "-r",
+        "--remote",
+        default="https://github.com/NixOS/nixpkgs",
+        help="Name of the nixpkgs repo to review",
     )
 
     wip_parser.set_defaults(func=wip_command)


### PR DESCRIPTION
Partially addresses #44 (but doesn't fully support private
repositories).