### PR TITLE
buildenv: simplify the config

### DIFF
--- a/nix_review/buildenv.py
+++ b/nix_review/buildenv.py
@@ -37,7 +37,7 @@ class Buildenv:
         os.environ["GIT_COMMITTER_EMAIL"] = "nix-review@example.com"
 
         self.nixpkgs_config = NamedTemporaryFile()
-        self.nixpkgs_config.write(b"pkgs: { allowUnfree = true; }")
+        self.nixpkgs_config.write(b"{ allowUnfree = true; }")
         self.nixpkgs_config.flush()
         os.environ["NIXPKGS_CONFIG"] = self.nixpkgs_config.name
 


### PR DESCRIPTION
It's not necessary to use a function since we don't use the pkgs
attribute. The config can just be an attribute set.

Related to https://github.com/NixOS/nixpkgs/pull/72376#discussion_r341883853